### PR TITLE
Cambia nome a xsl di fix rndt2

### DIFF
--- a/catalog/config/batch-process-cfg.json
+++ b/catalog/config/batch-process-cfg.json
@@ -28,7 +28,7 @@
     "type": "fixed-params",
     "params": []
   },{
-  "key": "to-rndt2",
+  "key": "fix-rndt2",
   "type": "fixed-params",
   "params": []
   },{

--- a/catalog/locales/it-admin.json
+++ b/catalog/locales/it-admin.json
@@ -57,7 +57,7 @@
     "batchreplacer-addReplacement": "Aggiungi sostituzione",
     "massive-search-and-replace": "Cerca e sostituisci",
     "batchreplacer-vacuum-mode": "Modalità vacuum",
-    "to-rndt2": "Aggiorna a RNDT v2",
+    "fix-rndt2": "Correggi metadati RNDT v2",
     "schemaVersion": "Schema version:",
     "appMinorVersionSupported": "Application minor version supported:",
     "appMajorVersionSupported": "Application major version supported:",


### PR DESCRIPTION
Per evitare confusioni quando sarà presente l'xsl di conversione rndt1->rndt2, la pr modifica il nome dello stile di trasformazione per fixare i metadati da to-rndt2 a fix-rndt2